### PR TITLE
Speaker starter kit intial materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Aim to provide three files with your presentation:
 More details and tips for each of these files are included below.
 Also included are templates for your talk description that will be published on Meetup and sent out to the @TampaUseRs group.
 
+## Talk Prep Checklist
+
+- [ ] Choose a [presentation topic](#planning-your-talk-topic)
+- [ ] Send @tgerke or @jhcreed your [talk description](#talk-description)
+- [ ] (Prepare your slides)[#slides-and-presentation-tips]
+- [ ] Write a [companion R script](#companion-script)
+- [ ] If using this speaker kit, rename or remove the speaker kit's `README.md`
+- [ ] Create a [README for your talk](#talk-readme)
+- [ ] [Submit your talk materials](#submit-your-talk-materials)
+
 ## Planning Your Talk Topic
 
 Plan for a 20-30 minute talk.
@@ -42,14 +52,6 @@ Working through an example is an excellent way to demonstrate a package or techn
 If using an external dataset or data source in your examples, try to use only one dataset.
 That way, you'll only have to explain your data structure one time in your talk.
 Remember: you'll be presenting to data enthusiasts who love to poke around a good dataset and will certainly want to ask questions about the dataset you choose.
-
-## Talk Prep Checklist
-
-- [ ] Send @tgerke or @jhcreed your [talk description](#talk-description)
-- [ ] Write a [companion R script](#companion-script)
-- [ ] If using this speaker kit, rename or remove the speaker kit's `README.md`
-- [ ] Create a [README for your talk](#talk-readme)
-- [ ] [Submit your talk materials](#submit-your-talk-materials)
 
 ## Talk Description
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Also included are templates for your talk description that will be published on 
 
 - [ ] Choose a [presentation topic](#planning-your-talk-topic)
 - [ ] Send @tgerke or @jhcreed your [talk description](#talk-description)
-- [ ] (Prepare your slides)[#slides-and-presentation-tips]
+- [ ] [Prepare your slides](#slides-and-presentation-tips)
 - [ ] Write a [companion R script](#companion-script)
 - [ ] If using this speaker kit, rename or remove the speaker kit's `README.md`
 - [ ] Create a [README for your talk](#talk-readme)

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Also included are templates for your talk description that will be published on 
 
 #### Three weeks before your talk
 
-- [ ] Confirm your presentation date with the TampaUsers organizers via our [Meetup page][trug-meetup]
+- [ ] Confirm your presentation date with the TampaUsers organizers at <UseRTampa@gmail.com> or via our [Meetup page][trug-meetup]
 
 #### Two weeks before your talk
 
 - [ ] Choose a [presentation topic](#planning-your-talk-topic)
-- [ ] Send your [talk description](#talk-description) to TampaUsers organizers via [Meetup][trug-meetup]
+- [ ] Send your [talk description](#talk-description) to TampaUsers organizers at <UseRTampa@gmail.com> or via [Meetup][trug-meetup]
 
 #### Prepare your talk
 
@@ -211,7 +211,7 @@ There are three ways to have your slides included in this repository:
 
     7. Navigate to your fork on GitHub, choose your new branch from the "Branch" drop-down menu near the top of the page, and then select "New Pull Request". By default, GitHub will choose the master branch of the TampaUseRs repo, but check that this is the "base" branch. Enter a short description and click "Create Pull Request".
 
-2. Contact the Tampa R Users Group meetup organizers via our [Meetup page][trug-meetup] to send the materials via email.
+2. Send your materials to Tampa R Users Group meetup organizers at <UseRTampa@gmail.com>.
 
 3. Host your slide materials online (GitHub, personal website, etc.) and send the link to us via [Twitter][trug-twitter] or [Meetup][trug-meetup].
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## How to Use This Kit
 
-This kit provides starter files for preparing for your Tampa R Users Group talk that will make it easier for you to prepare, for the attendees to follow along, and for the organizers to stay organized.
+This kit provides starter files for preparing for your [Tampa R Users Group][trug-website] talk that will make it easier for you to prepare, for the attendees to follow along, and for the organizers to stay organized.
 
 If you're comfortable with git and GitHub, you can fork this kit and use it as a starting place for you talk development.
 You could also just clone this repo locally and start there.
@@ -23,12 +23,12 @@ Aim to provide three files with your presentation:
     - a list of required packages to run the script.
 
 More details and tips for each of these files are included below.
-Also included are templates for your talk description that will be published on Meetup and sent out to the @TampaUseRs group.
+Also included are templates for your talk description that will be published on [Meetup][trug-meetup] and sent out to the [Tampa R Users Group][trug-website].
 
 ## Talk Prep Checklist
 
 - [ ] Choose a [presentation topic](#planning-your-talk-topic)
-- [ ] Send @tgerke or @jhcreed your [talk description](#talk-description)
+- [ ] Send your [talk description](#talk-description) to TampaUsers organizers via our [Meetup page][trug-meetup]
 - [ ] [Prepare your slides](#slides-and-presentation-tips)
 - [ ] Write a [companion R script](#companion-script)
 - [ ] If using this speaker kit, rename or remove the speaker kit's `README.md`
@@ -45,7 +45,7 @@ To keep your talk focused, start by focusing on a single take-away for the audie
 > After my talk, participants **will be able to...**
 
 You don't need to cover every corner or possible use case of your chosen methodology or package.
-If you are presenting about a package, stick to the most important functions or features. 
+If you are presenting about a package, stick to the most important functions or features.
 If you'll be discussing a technique or methodology, focus on the most tricky aspects that are hard to understand and can benefit from your expertise.
 
 Working through an example is an excellent way to demonstrate a package or technique.
@@ -56,7 +56,7 @@ Remember: you'll be presenting to data enthusiasts who love to poke around a goo
 ## Talk Description
 
 You can use this template as a starting point for your talk description.
-This will be published on Meetup and our website and may be included in announcement emails sent by Meetup.
+This will be published on [Meetup][trug-meetup] and [our website][trug-website] and may be included in announcement emails sent by Meetup.
 You only need to replace the parts in `{}`, or feel free to use the template as a starting point.
 
 ```plain
@@ -69,28 +69,10 @@ Learn {how to|about} {package|method|skill|approach|etc.}!
 {He|She|They} can be found online at {Twitter}, {Linkedin}, or {personal website}.
 ```
 
-When you've settled on your talk topic, send your description to @jhcreed so that we can announce your talk.
+When you've settled on your talk topic, send your description to the meetup organizers via our [Meetup page][trug-meetup] or [&commat;UseRsTampa][trug-twitter] so that we can announce your talk.
 If you include your Twitter handle, we'll be sure to include you in any posts.
 
 ## Slides and Presentation Tips
-
-### Using R Markdown to Prepare Your Slides
-
-In addition to traditional slide-creation software like Microsoft PowerPoint or Apple Keynote, there are several R-centric, literate programming frameworks available based on [R Markdown][rmarkdown].
-
-R Markdown is a plain-text markup language that lets you style regular text (like making a word **bold** with `**asterisks**`).
-More importantly, it also allows you to blend R code into your documents and slides, showcasing both the code and its results.
-RStudio's [Introduction to R Markdown](https://rmarkdown.rstudio.com/lesson-1.html) is an excellent place to get started.
-
-RStudio's markdown guide also includes a section on [Slide Presentations](https://rmarkdown.rstudio.com/lesson-11.html), where they demonstrate using R Markdown do render:
-
-- [PDF presentations with beamer](http://rmarkdown.rstudio.com/beamer_presentation_format.html)
-- [HTML presentations with ioslides](http://rmarkdown.rstudio.com/ioslides_presentation_format.html)
-- [HTML presentations with slidy](http://rmarkdown.rstudio.com/slidy_presentation_format.html)
-- [HTML presentations with reveal.js](http://rmarkdown.rstudio.com/revealjs_presentation_format.html)
-- [PowerPoint presentations](https://bookdown.org/yihui/rmarkdown/powerpoint-presentation.html)
-
-We also recommend the [xaringan] package for creating HTML and CSS-based presentations -- and you can customize your slide styles using the [xaringanthemer] package from a Tampa UseR.
 
 ### Presentation Tips
 
@@ -98,7 +80,7 @@ In our current environment, we use flat screen televisions in a medium-sized roo
 
 - Use a wide-screen 16:9 format.
 
-- Use large fonts that are easily readable at a distance. (Definitely increase the default size of whatever presentation software/package you use.)
+- Use large fonts that are easily readable at a distance. (As a starting point, try increasing the default size of your presentation software/package by 130%.)
 
 - Format your R code for easy readability and understandability, using descriptive variable names, extra lines, whitespace, etc.
 
@@ -114,11 +96,44 @@ If you're brave, live coding is encouraged.
 
 - Increase the viewing size of your RStudio or terminal window using <kbd>Ctrl</kbd>/<kdb>&#8984;</kbd> + <kbd>+</kdb>.
 
+- Review tips in the Software Carpentry Foundation's [Live Coding Instructor Training](https://carpentries.github.io/instructor-training/15-live/).
+
+There are some really great presentation (and self-marketing) tips in Jenny Bryan's [Carpe Talk](https://www.tidyverse.org/articles/2018/07/carpe-talk/) tidyverse blog post.
+Here are three resources that can dramatically increase the effectiveness of your presentation:
+
+1. [7 Tips for Presenting Bulleted Lists in Digital Content](https://www.nngroup.com/articles/presenting-bulleted-lists/) by David L. Stern
+
+2. [The Art of Slide Design](https://speakerdeck.com/mseckington/the-art-of-slide-design) by Melinda Seckington
+
+3. [Presenting Effectively](https://kieranhealy.org/blog/archives/2018/03/24/making-slides/) by Kieran Healy
+
+### Using R Markdown to Prepare Your Slides
+
+You're welcome to make your slides in the presentation software of your choice.
+(You don't even have to make slides if you'd rather [live code](https://carpentries.github.io/instructor-training/15-live/).)
+It's a good idea to export your slides as PDF for sharing.
+
+If you're not afraid of getting meta and using R to make your slides about R, you can use one of the available literate programming frameworks based on [R Markdown][rmarkdown].
+
+R Markdown is a plain-text markup language that lets you style regular text (like making a word **bold** with `**asterisks**`).
+More importantly, it also allows you to blend R code into your documents and slides, showcasing both the code and its results.
+RStudio's [Introduction to R Markdown](https://rmarkdown.rstudio.com/lesson-1.html) is an excellent place to get started.
+
+RStudio's markdown guide also includes a section on [Slide Presentations](https://rmarkdown.rstudio.com/lesson-11.html), where they demonstrate using R Markdown to render:
+
+- [PDF presentations with beamer](http://rmarkdown.rstudio.com/beamer_presentation_format.html)
+- [HTML presentations with ioslides](http://rmarkdown.rstudio.com/ioslides_presentation_format.html)
+- [HTML presentations with slidy](http://rmarkdown.rstudio.com/slidy_presentation_format.html)
+- [HTML presentations with reveal.js](http://rmarkdown.rstudio.com/revealjs_presentation_format.html)
+- [PowerPoint presentations](https://bookdown.org/yihui/rmarkdown/powerpoint-presentation.html)
+
+We also recommend the [xaringan] package for creating HTML and CSS-based presentations -- and you can customize your slide styles using the [xaringanthemer] package from a Tampa UseR.
+
 ## Companion Script
 
 Including a companion script with your talk will help participants follow along both during your talk and afterwards at home.
 
-If you've used an R Markdown based framework to build your slides, you can create a companion script from the code included in your slides by using the [knitr] function `purl()` to extract the R code chunks in your slide into a single script.
+If you've used an [R Markdown based framework](#using-r-markdown-to-prepare-your-slides) to build your slides, you can create a companion script from the code included in your slides by using the [knitr] function `purl()` to extract the R code chunks in your slide into a single script.
 
 ```r
 knitr::purl("slides.Rmd")
@@ -159,18 +174,22 @@ There are three ways to have your slides included in this repository:
 1. Submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request/) to the [TampaUseRs/TampaUseRs](https://github.com/TampaUseRs/TampaUseRs) repo. To do this:
 
     1. Fork the [TampaUseRs/TampaUseRs](https://github.com/TampaUseRs/TampaUseRs) repo into your GitHub account.
-    1. Clone the repo to your local computer.
-    1. Create a new branch for your slides. Inside the repo folder, run
+    2. Clone the repo to your local computer.
+    3. Create a new branch for your slides. Inside the repo folder, run
 
-        `git checkout -b my-presentation`
+        ```bash
+        git checkout -b my-presentation
+        ```
 
-    1. Create a folder in `meetups` with the date and short description of your talk:
+    4. Create a folder in `meetups` with the date and short description of your talk:
 
-        `meetups/YYYYMMDD-talk-topic`
+        ```bash
+        meetups/YYYYMMDD-talk-topic
+        ```
 
-    1. Add your slides, code and additional files.
+    5. Add your slides, code and additional files.
 
-    1. Commit these files to your local repo and push to your fork on GitHub
+    6. Commit these files to your local repo and push to your fork on GitHub
 
         ```bash
         git add -u
@@ -178,13 +197,16 @@ There are three ways to have your slides included in this repository:
         git push -u origin my-presentation
         ```
 
-    1. Navigate to your fork on GitHub, choose your new branch from the "Branch" drop down menu near the top of the page, and then select "New Pull Request". By default, GitHub will choose the master branch of the TampaUseRs repo, but check that this is the "base" branch. Enter a short description and click "Create Pull Request".
+    7. Navigate to your fork on GitHub, choose your new branch from the "Branch" drop-down menu near the top of the page, and then select "New Pull Request". By default, GitHub will choose the master branch of the TampaUseRs repo, but check that this is the "base" branch. Enter a short description and click "Create Pull Request".
 
-1. Send the slide materials by email to one of [the group admins](https://github.com/orgs/TampaUseRs/people?utf8=%E2%9C%93&query=+role%3Aowner).
+2. Contact the Tampa R Users Group meetup organizers via our [Meetup page][trug-meetup] to send the materials via email.
 
-1. Host your slide materials online (GitHub, personal website, etc.) and send the link to one of [the group admins](https://github.com/orgs/TampaUseRs/people?utf8=%E2%9C%93&query=+role%3Aowner).
+3. Host your slide materials online (GitHub, personal website, etc.) and send the link to us via [Twitter][trug-twitter] or [Meetup][trug-meetup].
 
 [knitr]: https://yihui.name/knitr
 [xaringan]: https://github.com/yihui/xaringan
 [xaringanthemer]: https://pkg.garrickadenbuie.com/xaringanthemer
 [rmarkdown]: https://rmarkdown.rstudio.com/
+[trug-meetup]: https://www.meetup.com/Tampa-R-Users-Group/
+[trug-website]: https://tampausers.github.io
+[trug-twitter]: https://www.twitter.com/UseRTampa/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,188 @@
-# speaker-starter-kit
-Starter Kit for Tampa R Users Group Meetup Speakers
+# Starter Kit for Tampa R Users Group Speakers
+
+<a href="https://tampausers.github.io"><img align="right" src="https://raw.githubusercontent.com/TampaUseRs/TampaUseRs/master/assets/hex-logo/trug-hex-800.png" width="250px"></a>
+
+## How to Use This Kit
+
+This kit provides starter files for preparing for your Tampa R Users Group talk that will make it easier for you to prepare, for the attendees to follow along, and for the organizers to stay organized.
+
+If you're comfortable with git and GitHub, you can fork this kit and use it as a starting place for you talk development.
+You could also just clone this repo locally and start there.
+
+If you'd rather not deal with git or GitHub, you can [download this repo as a zip file](https://github.com/TampaUseRs/speaker-starter-kit/archive/master.zip) and start there.
+
+This document contains some instructions and guidelines for speakers based on best practices learned from previous presentations.
+
+Aim to provide three files with your presentation:
+
+1. Your slides
+2. A companion R script
+3. A short README with
+    - a summary of your talk,
+    - links to data files (if needed), and
+    - a list of required packages to run the script.
+
+More details and tips for each of these files are included below.
+Also included are templates for your talk description that will be published on Meetup and sent out to the @TampaUseRs group.
+
+## Planning Your Talk Topic
+
+Plan for a 20-30 minute talk.
+This will give plenty of time for you to present on your topic, field questions, and digress into the details.
+
+To keep your talk focused, start by focusing on a single take-away for the audience:
+
+> After my talk, participants **will be able to...**
+
+You don't need to cover every corner or possible use case of your chosen methodology or package.
+If you are presenting about a package, stick to the most important functions or features. 
+If you'll be discussing a technique or methodology, focus on the most tricky aspects that are hard to understand and can benefit from your expertise.
+
+Working through an example is an excellent way to demonstrate a package or technique.
+If using an external dataset or data source in your examples, try to use only one dataset.
+That way, you'll only have to explain your data structure one time in your talk.
+Remember: you'll be presenting to data enthusiasts who love to poke around a good dataset and will certainly want to ask questions about the dataset you choose.
+
+## Talk Prep Checklist
+
+- [ ] Send @tgerke or @jhcreed your [talk description](#talk-description)
+- [ ] Write a [companion R script](#companion-script)
+- [ ] If using this speaker kit, rename or remove the speaker kit's `README.md`
+- [ ] Create a [README for your talk](#talk-readme)
+- [ ] [Submit your talk materials](#submit-your-talk-materials)
+
+## Talk Description
+
+You can use this template as a starting point for your talk description.
+This will be published on Meetup and our website and may be included in announcement emails sent by Meetup.
+You only need to replace the parts in `{}`, or feel free to use the template as a starting point.
+
+```plain
+Learn {how to|about} {package|method|skill|approach|etc.}!
+{Package|Method|Skill} {provides functions|can be used} to {complete exciting task}.
+{Your Name} will walk us through an example demonstrating {key task}.
+
+{Your Name} is an {occupation} at {company}, and uses R to {do fun things}.
+{More interesting things about yourself}.
+{He|She|They} can be found online at {Twitter}, {Linkedin}, or {personal website}.
+```
+
+When you've settled on your talk topic, send your description to @jhcreed so that we can announce your talk.
+If you include your Twitter handle, we'll be sure to include you in any posts.
+
+## Slides and Presentation Tips
+
+### Using R Markdown to Prepare Your Slides
+
+In addition to traditional slide-creation software like Microsoft PowerPoint or Apple Keynote, there are several R-centric, literate programming frameworks available based on [R Markdown][rmarkdown].
+
+R Markdown is a plain-text markup language that lets you style regular text (like making a word **bold** with `**asterisks**`).
+More importantly, it also allows you to blend R code into your documents and slides, showcasing both the code and its results.
+RStudio's [Introduction to R Markdown](https://rmarkdown.rstudio.com/lesson-1.html) is an excellent place to get started.
+
+RStudio's markdown guide also includes a section on [Slide Presentations](https://rmarkdown.rstudio.com/lesson-11.html), where they demonstrate using R Markdown do render:
+
+- [PDF presentations with beamer](http://rmarkdown.rstudio.com/beamer_presentation_format.html)
+- [HTML presentations with ioslides](http://rmarkdown.rstudio.com/ioslides_presentation_format.html)
+- [HTML presentations with slidy](http://rmarkdown.rstudio.com/slidy_presentation_format.html)
+- [HTML presentations with reveal.js](http://rmarkdown.rstudio.com/revealjs_presentation_format.html)
+- [PowerPoint presentations](https://bookdown.org/yihui/rmarkdown/powerpoint-presentation.html)
+
+We also recommend the [xaringan] package for creating HTML and CSS-based presentations -- and you can customize your slide styles using the [xaringanthemer] package from a Tampa UseR.
+
+### Presentation Tips
+
+In our current environment, we use flat screen televisions in a medium-sized room.
+
+- Use a wide-screen 16:9 format.
+
+- Use large fonts that are easily readable at a distance. (Definitely increase the default size of whatever presentation software/package you use.)
+
+- Format your R code for easy readability and understandability, using descriptive variable names, extra lines, whitespace, etc.
+
+- Favor easy to understand code structures over esoteric one-liners.
+
+- Clearly indicate the packages required for the demo code. If you can get away with a single `library(tidyverse)`, it's a great place to start.
+
+If you're brave, live coding is encouraged.
+
+- Practice your examples before your talk.
+
+- Type out your example code when possible. Live coding doesn't work as well if you simply run lines of code from a document because it's too easy to go too fast. In this case, it may be better to move your code to a slide where it's easier to read.
+
+- Increase the viewing size of your RStudio or terminal window using <kbd>Ctrl</kbd>/<kdb>&#8984;</kbd> + <kbd>+</kdb>.
+
+## Companion Script
+
+Including a companion script with your talk will help participants follow along both during your talk and afterwards at home.
+
+If you've used an R Markdown based framework to build your slides, you can create a companion script from the code included in your slides by using the [knitr] function `purl()` to extract the R code chunks in your slide into a single script.
+
+```r
+knitr::purl("slides.Rmd")
+# Writes out: slides.R
+```
+
+Otherwise, keep track of the code you demonstrate in a single script.
+
+It's important to also keep track of the packages that you use.
+Try to use packages that are popular and that are hosted on CRAN or BioConductor.
+Think carefully about including packages that are custom, difficult to setup, or not common for standard R installations, unless they are necessary or central to the topic of your talk.
+
+At the top of your companion slide, include the `install.packages()` or `devtools::install_github()` code that installs the packages required to run your scripts, but comment them out.
+This information will be duplicated in your talk README.
+
+## Talk README
+
+The speaker starter kit includes an example README file called [`README_example.md`](README_example.md) that you can use as a starting point.
+Remove or rename these speaker instructions and rename `README_example.md` to `README.md`.
+
+GitHub automatically renders README files at a folder root, so meetup participants who view your slides folder in [TampaUseRs/TampaUseRs/meetups](https://github.com/TampaUseRs/TampaUseRs/tree/master/meetups) will get an overview of your talk, the files they need to download, and packages they need to install before your presentation.
+For an example of how this looks, see the meetup from [2018-06-19](https://github.com/TampaUseRs/TampaUseRs/tree/master/meetups/20180619-machine-learning).
+
+In essence, this README should contain
+
+- The title of your talk
+- Description of your topic
+- Links to data files required
+- List of packages required
+- Your contact information (optional)
+
+## Submit Your Talk Materials
+
+The Tampa R Users Group hosts copies of slides and accompanying materials online at <https://github.com/TampaUseRs/TampaUseRs>.
+
+There are three ways to have your slides included in this repository:
+
+1. Submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request/) to the [TampaUseRs/TampaUseRs](https://github.com/TampaUseRs/TampaUseRs) repo. To do this:
+
+    1. Fork the [TampaUseRs/TampaUseRs](https://github.com/TampaUseRs/TampaUseRs) repo into your GitHub account.
+    1. Clone the repo to your local computer.
+    1. Create a new branch for your slides. Inside the repo folder, run
+
+        `git checkout -b my-presentation`
+
+    1. Create a folder in `meetups` with the date and short description of your talk:
+
+        `meetups/YYYYMMDD-talk-topic`
+
+    1. Add your slides, code and additional files.
+
+    1. Commit these files to your local repo and push to your fork on GitHub
+
+        ```bash
+        git add -u
+        git commit -m "Add slides for my talk topic"
+        git push -u origin my-presentation
+        ```
+
+    1. Navigate to your fork on GitHub, choose your new branch from the "Branch" drop down menu near the top of the page, and then select "New Pull Request". By default, GitHub will choose the master branch of the TampaUseRs repo, but check that this is the "base" branch. Enter a short description and click "Create Pull Request".
+
+1. Send the slide materials by email to one of [the group admins](https://github.com/orgs/TampaUseRs/people?utf8=%E2%9C%93&query=+role%3Aowner).
+
+1. Host your slide materials online (GitHub, personal website, etc.) and send the link to one of [the group admins](https://github.com/orgs/TampaUseRs/people?utf8=%E2%9C%93&query=+role%3Aowner).
+
+[knitr]: https://yihui.name/knitr
+[xaringan]: https://github.com/yihui/xaringan
+[xaringanthemer]: https://pkg.garrickadenbuie.com/xaringanthemer
+[rmarkdown]: https://rmarkdown.rstudio.com/

--- a/README.md
+++ b/README.md
@@ -27,12 +27,24 @@ Also included are templates for your talk description that will be published on 
 
 ## Talk Prep Checklist
 
+#### Three weeks before your talk
+
+- [ ] Confirm your presentation date with the TampaUsers organizers via our [Meetup page][trug-meetup]
+
+#### Two weeks before your talk
+
 - [ ] Choose a [presentation topic](#planning-your-talk-topic)
-- [ ] Send your [talk description](#talk-description) to TampaUsers organizers via our [Meetup page][trug-meetup]
+- [ ] Send your [talk description](#talk-description) to TampaUsers organizers via [Meetup][trug-meetup]
+
+#### Prepare your talk
+
 - [ ] [Prepare your slides](#slides-and-presentation-tips)
 - [ ] Write a [companion R script](#companion-script)
 - [ ] If using this speaker kit, rename or remove the speaker kit's `README.md`
 - [ ] Create a [README for your talk](#talk-readme)
+
+#### 1-3 days before your talk
+
 - [ ] [Submit your talk materials](#submit-your-talk-materials)
 
 ## Planning Your Talk Topic

--- a/README_example.md
+++ b/README_example.md
@@ -1,0 +1,63 @@
+---
+title: Your Talk Title
+presenter: Your Name
+date: 2006-01-02
+email: you@email.com     # if you want, delete otherwise
+twitter: @yourhandle     # if you want, delete otherwise
+web: https://www.you.com # if you want, delete otherwise
+---
+
+## Description
+
+Copy your talk description here.
+
+```
+Learn {how to|about} {package|method|skill|approach|etc.}!
+{Package|Method|Skill} {provides functions|can be used} to {complete exciting task}.
+{Your Name} will walk us through an example demonstrating {key task}.
+
+{Your Name} is an {occupation} at {company}, and uses R to {do fun things}.
+{More interesting things about yourself}.
+{He|She|They} can be found online at {Twitter}, {Linkedin}, or {personal website}.
+```
+
+## Setup
+
+Included files:
+
+- [slides-file-name.pdf](slides-file-name.pdf) is the presentation slides
+- [slides-file-name.Rmd](slides-file-name.Rmd) is the source code for the slides
+- [companion-script.R](companion-script.R) is the companion R code for the talk
+
+Include any additional notes about setup or prep required for participants to be able to follow along at the talk or at home.
+
+## Data
+
+Links to your data sources (external or included in this folder).
+
+## Packages Used
+
+List the packages used for your code.
+If a particular package is the focus of your talk, be sure to include a link to that package's documentation.
+
+To automatically find the R packages you used in your slides/code, you can try the [automagic](https://cran.r-project.org/package=automagic) package.
+
+```r
+cran_pkgs <- c(
+  "ggplot2",
+  "dplyr",
+  "caret",
+  "randomForest",
+  "devtools"
+)
+
+install.packages(cran_pkgs)
+
+github_pkgs <- c(
+  "mkearney/rtweet",
+  "tidyverse/glue",
+  "gadenbuie/xaringanthemer"
+)
+
+devtools::install_github(github_pkgs)
+```

--- a/README_example.md
+++ b/README_example.md
@@ -2,9 +2,9 @@
 title: Your Talk Title
 presenter: Your Name
 date: 2006-01-02
-email: you@email.com     # if you want, delete otherwise
-twitter: @yourhandle     # if you want, delete otherwise
-web: https://www.you.com # if you want, delete otherwise
+email: you@email.com
+twitter: "@yourhandle"
+web: https://www.example.com
 ---
 
 ## Description

--- a/YYYYMMDD-topic-companion.R
+++ b/YYYYMMDD-topic-companion.R
@@ -1,0 +1,35 @@
+# ---- Talk Title Companion R Script ----
+
+# title: Your Talk Title
+# presenter: Your Name
+# date: 2006-01-02
+# email: you@email.com     # if you want, delete otherwise
+# twitter: @yourhandle     # if you want, delete otherwise
+# web: https://www.you.com # if you want, delete otherwise
+
+# ---- Packages ----
+cran_pkgs <- c(
+  "ggplot2",
+  "dplyr",
+  "caret",
+  "randomForest",
+  "devtools"
+)
+
+# install.packages(cran_pkgs)
+
+github_pkgs <- c(
+  "mkearney/rtweet",
+  "tidyverse/glue",
+  "gadenbuie/xaringanthemer"
+)
+
+# devtools::install_github(github_pkgs)
+
+# ---- Slide Code ----
+
+# Add your code here...
+
+# Break into sections using section headers (like above)
+# so that attendees can use RStudio's navigation
+# controls to jump between sections.


### PR DESCRIPTION
This PR adds speaker guidelines with a speaker checklist, resources, tips, and more, in addition to a talk README template and a starter R companion script.

My hope is that this streamlines a lot of the process in terms of prepping for a talk and updating our online materials, while establishing a consistent starting point for our speakers.

Your feedback is welcomed -- especially @thomas-keller as our next presenter!

It's probably easier to review if you look at the [repo at this branch](https://github.com/TampaUseRs/speaker-starter-kit/tree/draft-materials).